### PR TITLE
Import parser

### DIFF
--- a/aws_inspector_auto_assessment.py
+++ b/aws_inspector_auto_assessment.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import boto3
+from dateutil import parser
 from botocore.exceptions import ClientError
 
 def get_latest_ami(ec2_conn, ami_filter, nodetype):


### PR DESCRIPTION
If you hit multiple AMI's comparison breaks because parser is not imported from dateutil